### PR TITLE
feat(widget): integrate jotai for state management; update package.js…

### DIFF
--- a/apps/widget/components/providers.tsx
+++ b/apps/widget/components/providers.tsx
@@ -2,13 +2,14 @@
 
 import * as React from "react"
 import { ConvexProvider, ConvexReactClient } from "convex/react"
+import { Provider } from "jotai"
 
 const convexClient = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
 
 export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <ConvexProvider client={convexClient}>
-      {children}
+      <Provider>{children}</Provider>
     </ConvexProvider>
       
    

--- a/apps/widget/modules/widget/atoms/widget-atoms.ts
+++ b/apps/widget/modules/widget/atoms/widget-atoms.ts
@@ -1,0 +1,5 @@
+import { atom } from "jotai"
+import { WidgetScreen } from "../types"
+
+// basic widget state atoms
+export const screenAtoms = atom<WidgetScreen>("auth");

--- a/apps/widget/modules/widget/constants.ts
+++ b/apps/widget/modules/widget/constants.ts
@@ -1,0 +1,12 @@
+export const WIDGET_SCREENS = [
+    "error",
+    "loading",
+    "selection",
+    "voice",
+    "auth",
+    "inbox",
+    "chat",
+    "contact",
+] as const
+
+export const CONTACT_SESSION_KEY = "echo_contact_session"

--- a/apps/widget/modules/widget/types.ts
+++ b/apps/widget/modules/widget/types.ts
@@ -1,0 +1,3 @@
+import { WIDGET_SCREENS } from "./constants"
+
+export type WidgetScreen = (typeof WIDGET_SCREENS)[number];

--- a/apps/widget/modules/widget/ui/views/widget-view.tsx
+++ b/apps/widget/modules/widget/ui/views/widget-view.tsx
@@ -1,10 +1,10 @@
 "use client"
 
-import { WidgetFooter } from "../components/widget-footer";
-import { WidgetHeader } from "../components/widget-header";
+import { useAtomValue } from "jotai";
 import { WidgetAuthScreen } from "../screens/widget-auth-screen";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@workspace/ui/components/form"
-import { Button } from "@workspace/ui/components/button"
+import { screenAtoms } from "../../atoms/widget-atoms";
+import { WIDGET_SCREENS } from "../../constants";
+import { WidgetScreen } from "../../types";
 
 
 interface Props {
@@ -12,11 +12,25 @@ interface Props {
 }
 
 export const WidgetView = ({ organizationId }: Props) => {
+    const screen = useAtomValue(screenAtoms);
+
+    const screenComponents = {
+        error: <p>TODO: Error</p>,
+        loading: <p>TODO: loading</p>,
+        auth: <WidgetAuthScreen />,
+        voice: <p>TODO: voice</p>,  
+        inbox: <p>TODO: inbox</p>,
+        selection: <p>TODO: selection</p>,
+        chat: <p>TODO: chat</p>,
+        contact: <p>TODO: contact</p>
+    }
+    
     return (
         // TODO: Correct this to be min-h-svh
         <main className="min-h-svh min-w-svh flex h-full w-full flex-col overflow-hidden rounded-xl border bg-muted">
-            <WidgetAuthScreen />
-            {/* <WidgetFooter /> */}
+           {
+            screenComponents[screen]
+           }
         </main>
     )
 }

--- a/apps/widget/package.json
+++ b/apps/widget/package.json
@@ -18,6 +18,7 @@
     "@workspace/math": "workspace:*",
     "@workspace/ui": "workspace:*",
     "convex": "^1.27.0",
+    "jotai": "^2.14.0",
     "lucide-react": "^0.475.0",
     "next": "^15.4.5",
     "next-themes": "^0.4.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       convex:
         specifier: ^1.27.0
         version: 1.27.0(@clerk/clerk-react@5.46.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      jotai:
+        specifier: ^2.14.0
+        version: 2.14.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.9)(react@19.1.1)
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@19.1.1)
@@ -3494,6 +3497,24 @@ packages:
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
+
+  jotai@2.14.0:
+    resolution: {integrity: sha512-JQkNkTnqjk1BlSUjHfXi+pGG/573bVN104gp6CymhrWDseZGDReTNniWrLhJ+zXbM6pH+82+UNJ2vwYQUkQMWQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@babel/core': '>=7.0.0'
+      '@babel/template': '>=7.0.0'
+      '@types/react': '>=17.0.0'
+      react: '>=17.0.0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@babel/template':
+        optional: true
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -8201,6 +8222,13 @@ snapshots:
       supports-color: 8.1.1
 
   jiti@2.5.1: {}
+
+  jotai@2.14.0(@babel/core@7.28.4)(@babel/template@7.27.2)(@types/react@19.1.9)(react@19.1.1):
+    optionalDependencies:
+      '@babel/core': 7.28.4
+      '@babel/template': 7.27.2
+      '@types/react': 19.1.9
+      react: 19.1.1
 
   js-cookie@3.0.5: {}
 


### PR DESCRIPTION
…on and pnpm-lock.yaml to include jotai dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Dynamic widget view switching based on the current screen.
  - Initial screen defaults to “auth”.
  - Predefined list of supported screens (error, loading, selection, voice, auth, inbox, chat, contact).
  - Type-safe handling of screen states.

- Refactor
  - Introduced a global state provider to manage widget state across the app.

- Chores
  - Added a new dependency for state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->